### PR TITLE
Use requirement's package name in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,6 @@ setup(
 
     packages=['otr'],
     provides=['otr'],
-    install_requires=['gmpy2', 'zope.interface', 'application', 'cryptography']
+    install_requires=['gmpy2', 'zope.interface', 'python3-application', 'cryptography']
 )
 


### PR DESCRIPTION
Hello,
I am working on packaging `blink-qt` with Nix on behalf of NGI as part of the Summer of Nix program. In the course of that, I was finding that this package couldn't find `python3-application` -- I think it needs the package name instead of the module name here. Applying this as a patch seemed to get me past that error. It's possible I'm misunderstanding something, but if not you might want to merge this change.
Thanks,
Charlie